### PR TITLE
[add/admin] books-count/users-index

### DIFF
--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -14,6 +14,7 @@ class Admin::GenresController < ApplicationController
        redirect_to admin_genres_path
     else
       @genres = Genre.all
+      flash[:failure] = "投稿に失敗しました"
       render 'admin/genre#index'
     end
   end

--- a/app/controllers/admin/subjects_controller.rb
+++ b/app/controllers/admin/subjects_controller.rb
@@ -14,6 +14,7 @@ class Admin::SubjectsController < ApplicationController
        redirect_to admin_subjects_path
     else
        @subjects = Subject.all
+       flash[:failure] = "投稿に失敗しました"
        render 'admin/subject#index'
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -13,6 +13,12 @@ class Admin::UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     if @user.update(user_params)
+      # ステータス更新と共に紐づいた投稿も削除or有効にする
+      if @user.is_valid == true
+        @user.books.update(is_deleted: false)
+      else
+        @user.books.update(is_deleted: true)
+      end
       flash[:success] = "変更内容を保存しました!"
       redirect_to admin_user_path(@user)
     else

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -2,4 +2,6 @@ class Genre < ApplicationRecord
 
   has_many :books, dependent: :destroy
 
+  validates :name, presence: true, length: { in: 1..20 }
+
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -2,4 +2,6 @@ class Subject < ApplicationRecord
 
   has_many :books, dependent: :destroy
 
+  validates :name, presence: true, length: { in: 1..20 }
+
 end

--- a/app/views/admin/books/show.html.erb
+++ b/app/views/admin/books/show.html.erb
@@ -8,6 +8,9 @@
       <div class="admin-books-show__books-info-items">
 
         <table class="admin-books-show__base-info">
+          <% if @book.is_deleted == true %>
+            <font color="red"><p><strong>削除済みの投稿</strong></p></font>
+          <% end %>
         <td><%= link_to (image_tag(@book.large_image_url)), @book.item_url, target: :_blank, rel: "noopener noreferrer" %></td>
 
         <tbody>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -4,6 +4,7 @@
 
   <!--投稿フォーム-->
   <div class="books-search__form">
+    <%= flash[:failure] %>
     <%= form_with(model: @genre, :url => {:controller => "admin/genres"}) do |f| %>
       <%= f.text_field :name, placeholder: "ジャンル名を入力", autofocus: true, autocomplete: "ジャンル名を入力" %>
       <%= f.submit '新規作成', class: "btn btn-success", rows:"1", cols:"40" %>
@@ -19,7 +20,6 @@
 
     <div class="admin-genres-index__result-wrapper">
       <div class="admin-genres-index__result-wrapper-inner">
-
         <% @genres.each do |genre| %>
           <div class="admin-genres-index__result">
 

--- a/app/views/admin/genres/show.html.erb
+++ b/app/views/admin/genres/show.html.erb
@@ -18,7 +18,11 @@
 
               <tbody>
                 <tr>
-                  <th class="admin-genres-show__base-info-theme"></th>
+                  <th class="admin-genres-show__base-info-theme">
+                    <% if book.is_deleted == true %>
+                      <font color="red"><p><strong>削除済みの投稿</strong></p></font>
+                    <% end %>
+                  </th>
                   <th class="admin-genres-show__base-info-theme">タイトル</th>
                   <th class="admin-genres-show__base-info-theme">投稿したユーザー</th>
                   <th class="admin-genres-show__base-info-theme">投稿日</th>

--- a/app/views/admin/subjects/show.html.erb
+++ b/app/views/admin/subjects/show.html.erb
@@ -18,7 +18,11 @@
 
               <tbody>
                 <tr>
-                  <th class="admin-subjects-show__base-info-theme"></th>
+                  <th class="admin-subjects-show__base-info-theme">
+                    <% if book.is_deleted == true %>
+                      <font color="red"><p><strong>削除済みの投稿</strong></p></font>
+                    <% end %>
+                  </th>
                   <th class="admin-subjects-show__base-info-theme">タイトル</th>
                   <th class="admin-subjects-show__base-info-theme">投稿したユーザー</th>
                   <th class="admin-subjects-show__base-info-theme">投稿日</th>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -21,6 +21,7 @@
                   <th class="admin-users-index__base-info-theme"></th>
                   <th class="admin-users-index__base-info-theme">ユーザーID</th>
                   <th class="admin-users-index__base-info-theme">ユーザー名</th>
+                  <th class="admin-users-index__base-info-theme">投稿数</th>
                   <th class="admin-users-index__base-info-theme">ステータス</th>
                   <th class="admin-users-index__base-info-theme">登録日</th>
                 </tr>
@@ -32,9 +33,10 @@
                   </td>
                   <td class="admin-users-index__base-info-data"><%= user.id %></td>
                   <td class="admin-users-index__base-info-data"><%= link_to user.nick_name, admin_user_path(user), class:"link" %></td>
+                  <td class="admin-users-index__base-info-data"><%= user.books.count %></td>
                   <td class="admin-users-index__base-info-data">
                     <% if user.is_valid == false %>
-                      <strong class="text-secondary">退会済み</strong>
+                      <strong class="text-danger">退会済み</strong>
                     <% else %>
                       <strong class="text-success">有効</strong>
                     <% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -73,6 +73,9 @@
           <div class="admin-users-show__book-list-items">
 
             <div class="admin-users-show__book-list-picture text-center" >
+              <% if book.is_deleted == true %>
+                <font color="red"><p><strong>削除済みの投稿</strong></p></font>
+              <% end %>
               <span>
                 <%= link_to (image_tag(book.small_image_url)), book.item_url, target: :_blank, rel: "noopener noreferrer" %>
                 <%= link_to book.title, admin_book_path(book.id) %>


### PR DESCRIPTION
管理側ユーザー一覧画面で投稿数の表示、ジャンル・科目追加でバリデーション設置、管理側でのユーザーステータス変更時に投稿も同時に削除・復帰処理を実装